### PR TITLE
Updated Navbar Links (.html to .php)

### DIFF
--- a/480FinalProject_About.html
+++ b/480FinalProject_About.html
@@ -18,7 +18,7 @@
 <body>
   <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-      <a class="navbar-brand" href="480FinalProject_HomeBoot.html">Gallery</a>
+      <a class="navbar-brand" href="480FinalProject_HomeBoot.php">Gallery</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -33,7 +33,7 @@
             <a class="nav-link" href="480FinalProject_About.html">About</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="480FinalProject_ContactUs.html">Contact Us</a>
+            <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="480FinalProject_Admin.php">Admin</a>

--- a/480FinalProject_Admin.php
+++ b/480FinalProject_Admin.php
@@ -71,13 +71,13 @@
 
 
     </script>
-    <title>Gallery w/ Bootstrap</title>
+    <title>Gallery Admin</title>
 </head>
 
 <body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="http://localhost/480FinalProject/480FinalProject_HomeBoot.html">Gallery</a>
+        <a class="navbar-brand" href="http://localhost/480FinalProject/480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/480FinalProject_AdminACK.php
+++ b/480FinalProject_AdminACK.php
@@ -44,7 +44,7 @@
 <body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="http://localhost/480FinalProject/480FinalProject_HomeBoot.html">Gallery</a>
+        <a class="navbar-brand" href="http://localhost/480FinalProject/480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/480FinalProject_ContactUs.php
+++ b/480FinalProject_ContactUs.php
@@ -18,7 +18,7 @@
 <body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="480FinalProject_HomeBoot.html">Gallery</a>
+        <a class="navbar-brand" href="480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/480FinalProject_ContactUsACK.php
+++ b/480FinalProject_ContactUsACK.php
@@ -18,7 +18,7 @@
 <body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="480FinalProject_HomeBoot.html">Gallery</a>
+        <a class="navbar-brand" href="480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/480FinalProject_HomeBoot.php
+++ b/480FinalProject_HomeBoot.php
@@ -51,13 +51,13 @@
             });
         });
     </script>
-    <title>Gallery w/ Bootstrap</title>
+    <title>Gallery</title>
 </head>
 
 <body>
     <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="480FinalProject_HomeBoot.html">Gallery</a>
+        <a class="navbar-brand" href="480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -72,7 +72,7 @@
                     <a class="nav-link" href="480FinalProject_About.html">About</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="480FinalProject_ContactUs.html">Contact Us</a>
+                    <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us</a>
                 <li class="nav-item">
                     <a class="nav-link" href="480FinalProject_Admin.php">Admin</a>
                 </li>

--- a/480_FinalProject_BootPageTemplate.html
+++ b/480_FinalProject_BootPageTemplate.html
@@ -11,7 +11,7 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <a class="navbar-brand" href="#">Gallery</a>
+        <a class="navbar-brand" href="480FinalProject_HomeBoot.php">Gallery</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -26,7 +26,7 @@
                     <a class="nav-link" href="480FinalProject_About.html">About</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="480FinalProject_ContactUs.html">Contact Us</a>
+                    <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us</a>
                     <li class="nav-item">
                         <a class="nav-link" href="480FinalProject_Admin.php">Admin</a>
                     </li>


### PR DESCRIPTION
Noticed the Contact Us page was still listed as a .html file on home and the about pages, updated to .php. The Gallery link was listed as a .html file as well and was updated to .php. A minor title change was also made to the homepage since it's not necessary for it to say it was made with Bootstrap.