### PR TITLE
onkeyup allows for regex to be checked while typing

### DIFF
--- a/480FinalProject_Admin.php
+++ b/480FinalProject_Admin.php
@@ -28,22 +28,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
     <script>
-        $(document).ready(function(){
-            $(".galImage").hover(function(){
-                $(this).css("opacity", ".5");
-            }, function(){
-                $(this).css("opacity", "1");
-            });
-            $(".galImage").click(function(){
-                $('#bigImage').attr('src', $(this).attr('src'));
-                $('#imagemodal').modal('show');   
-            });
-        });
-
-
         //regex year
         function checkYear() {
-        var RegExp = /^[12][0-9]{2}$/; //I have no idea why /^[12][0-9]{3}$/ wasn't working, but {2} is a temp workaround
+        var RegExp = /^[12][0-9]{3}$/;
         var yearInput = document.getElementById("year").value;
         var errorSpan = document.getElementById("yearError");
         if(!RegExp.test(yearInput)) {
@@ -57,11 +44,11 @@
 
         //regex URL
         function checkURL() {
-        var RegExp = /images\//;
+        var RegExp = /^Images\/[a-zA-Z0-9]+\.(jpg|png|jpeg)$/;
         var urlInput = document.getElementById("urlInput").value;
         var errorSpan = document.getElementById("urlError");
         if(!RegExp.test(urlInput)) {
-            errorSpan.innerHTML = "<br>Error: Please enter a url in the form images/yourImageName.jpg"
+            errorSpan.innerHTML = "<br>Error: Please enter a url in the form Images/yourImageName.jpg"
         } else {
             console.log("submitted");
             errorSpan.innerHTML = "";
@@ -85,8 +72,8 @@
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" href="480FinalProject_HomeBoot.php">Home <span class="sr-only">(current)</span></a>
+                <li class="nav-item">
+                    <a class="nav-link" href="480FinalProject_HomeBoot.php">Home</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="480FinalProject_About.html">About</a>
@@ -94,8 +81,8 @@
                 <li class="nav-item">
                     <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us</a>
                 </li>
-                <li class="nav-item">
-                  <a class="nav-link" href="480FinalProject_Admin.php">Admin</a>
+                <li class="nav-item active">
+                  <a class="nav-link" href="480FinalProject_Admin.php">Admin<span class="sr-only">(current)</span></a>
               </li>
               <li class="nav-item">
                   <a class="nav-link" href="480FinalProject_LogIn.php">Log In</a>
@@ -163,7 +150,7 @@
         $sql = "SELECT * FROM artist";
         $result = $conn->query($sql);
         if(mysqli_query($conn, $sql)){
-          echo "<select name='artistID'>";
+          echo "<select name='artistID' class='form-control'>";
           while ($row = $result->fetch_assoc()) {
             echo "<option value='" . $row['artistID'] . "'>" . $row['fName'] . " " . $row['lName'] . "</option>";
           }
@@ -179,7 +166,7 @@
         <div class="form-group">
           <label>Medium</label>
           <input type="text" name="medium" class="form-control" id="medium" placeholder="Medium of artwork" autocomplete="off">
-          <small id="mediumHelp" class="form-text text-muted">Specify the medium of the piece. Ex: painting, photograph, sculputre, etc</small>
+          <small id="mediumHelp" class="form-text text-muted">Specify the medium of the piece. Ex: painting, photograph, sculpture, etc</small>
         </div>
         <!--PRICE INPUT-->
         <div class="form-group">
@@ -190,17 +177,17 @@
           <!--YEAR INPUT-->
           <div class="form-group">
             <label>Year</label>
-            <input type="number" name="year" class="form-control" id="year" placeholder="Year the artwork was created" onkeydown= "checkYear()" autocomplete="off">
+            <input type="number" name="year" class="form-control" id="year" placeholder="Year the artwork was created" onkeyup= "checkYear()" autocomplete="off">
             <span class='error' id='yearError'></span>
             <p></p>
             <small id="yearHelp" class="form-text text-muted">Specify the Year of the piece </small>
           </div>
       <div class="form-group">
           <label>URL</label>
-          <input type="text" name="url" class="form-control" id="urlInput" placeholder="Enter the URL of the artwork" onkeydown="checkURL()" autocomplete="off">
+          <input type="text" name="url" class="form-control" id="urlInput" placeholder="Enter the URL of the artwork" onkeyup="checkURL()" autocomplete="off">
           <span class='error' id='urlError'></span>
             <p></p>
-          <small id="urlHelp" class="form-text text-muted">Add the URL to the artwork. Use format images/yourImage.jpg </small>
+          <small id="urlHelp" class="form-text text-muted">Add the URL to the artwork. Use format Images/yourImage.jpg </small>
         </div>
         <button type="submit" class="btn btn-outline-success btn-block" style="width: 25%;">Submit</button>
         </form> 

--- a/480FinalProject_ContactUs.php
+++ b/480FinalProject_ContactUs.php
@@ -12,6 +12,71 @@
     integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.7/css/all.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script>
+  function checkPhone(){
+    var RegExp = /^[0-9]{3}\-[0-9]{3}\-[0-9]{4}$/;
+        var phoneInput = document.getElementById("phoneInput").value;
+        var errorSpan = document.getElementById("phoneError");
+        if(!RegExp.test(phoneInput)) {
+            errorSpan.innerHTML = "Error: Please enter a phone number in the format xxx-xxx-xxxx"
+        } else {
+            console.log("submitted");
+            errorSpan.innerHTML = "";
+        }
+  }
+
+  function checkFName(){
+    var RegExp = /^[A-Z]{1}[a-z]{1,}$/;
+        var fNameInput = document.getElementById("fNameInput").value;
+        var errorSpan = document.getElementById("fNameError");
+        if(!RegExp.test(fNameInput)) {
+            errorSpan.innerHTML = "Error: Please enter a first name like Al, Ann, or Lupin."
+        } else {
+            console.log("submitted");
+            errorSpan.innerHTML = "";
+        }
+  }
+
+  function checkLName(){
+    var RegExp = /[A-Z]{1}[a-z]+$/;
+        var lNameInput = document.getElementById("lNameInput").value;
+        var errorSpan = document.getElementById("lNameError");
+        if(!RegExp.test(lNameInput)) {
+            errorSpan.innerHTML = "Error: Please enter a last name like Smith, Drake, or Zenigata."
+        } else {
+            console.log("submitted");
+            errorSpan.innerHTML = "";
+        }
+  }
+  function checkTitle(){
+    var RegExp = /[A-Z]{1}[a-z]+$/;
+        var titleInput = document.getElementById("titleInput").value;
+        var errorSpan = document.getElementById("titleError");
+        if(!RegExp.test(titleInput)) {
+            errorSpan.innerHTML = "Error: Please enter a title like Artist, Web Developer, or Artistic Lead."
+        } else {
+            console.log("submitted");
+            errorSpan.innerHTML = "";
+        }
+  }
+  function checkMessage(){
+    var RegExp = /(\w+\,?(\s|\.))+/;
+        var customerMessageInput = document.getElementById("customerMessageInput").value;
+        var errorSpan = document.getElementById("customerMessageError");
+        if(!RegExp.test(customerMessageInput)) {
+            errorSpan.innerHTML = "Error: Please type a little more if you're going to leave a message."
+        } else {
+            console.log("submitted");
+            errorSpan.innerHTML = "";
+        }
+  }
+  
+  </script>
+  <style>
+    .error {
+            color: red;
+        }
+  </style>
 
 </head>
 
@@ -26,14 +91,14 @@
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" href="480FinalProject_HomeBoot.php">Home <span class="sr-only">(current)</span></a>
+                <li class="nav-item">
+                    <a class="nav-link" href="480FinalProject_HomeBoot.php">Home</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="480FinalProject_About.html">About</a>
                 </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us</a>
+                <li class="nav-item active">
+                    <a class="nav-link" href="480FinalProject_ContactUs.php">Contact Us<span class="sr-only">(current)</span></a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="480FinalProject_Admin.php">Admin</a>
@@ -72,7 +137,10 @@
                   <!-- Grid column -->
                   <div class="col-md-6">
                     <div class="md-form mb-0">
-                      <input type="text" id="fName" name="fName" class="form-control" autocomplete="off">
+                      <input type="text" id="fNameInput" name="fNameInput" class="form-control" autocomplete="off" onkeyup="checkFName()">
+                      <small class='error' id='fNameError'></small>
+                      <p></p>
+                      <!--<small id="fNameHelp" class="form-text text-muted">Type a name like Al, Ann, or Lupin. </small>-->
                       <label for="form-contact-name" class="">First Name</label>
                     </div>
                   </div>
@@ -81,7 +149,10 @@
                   <!-- Grid column -->
                   <div class="col-md-6">
                     <div class="md-form mb-0">
-                      <input type="text" id="lName" name="lName" class="form-control" autocomplete="off">
+                      <input type="text" id="lNameInput" name="lNameInput" class="form-control" autocomplete="off" onkeyup="checkLName()">
+                      <small class='error' id='lNameError'></small>
+                      <p></p>
+                      <!--<small id="lNameHelp" class="form-text text-muted">Type a last name like Smith, Drake, or Zenigata.</small>-->
                       <label for="form-contact-email" class="">Last Name</label>
                     </div>
                   </div>
@@ -96,7 +167,10 @@
                   <!-- Grid column -->
                   <div class="col-md-6">
                     <div class="md-form mb-0">
-                      <input type="number" id="phoneNumber" name="phoneNumber" class="form-control" autocomplete="off">
+                      <input type="text" id="phoneInput" name="phoneInput" class="form-control" autocomplete="off" onkeyup="checkPhone()">
+                      <small class='error' id='phoneError'></small>
+                      <p></p>
+                      <!--<small id="phoneHelp" class="form-text text-muted">Type a phone number in the xxx-xxx-xxxx format.</small>-->
                       <label for="form-contact-phone" class="">Your phone</label>
                     </div>
                   </div>
@@ -105,7 +179,10 @@
                   <!-- Grid column -->
                   <div class="col-md-6">
                     <div class="md-form mb-0">
-                      <input type="text" id="title" name="title" class="form-control" autocomplete="off">
+                      <input type="text" id="titleInput" name="titleinput" class="form-control" autocomplete="off" onkeyup="checkTitle()">
+                      <small class='error' id='titleError'></small>
+                      <p></p>
+                      <!--<small id="lNameHelp" class="form-text text-muted">Type a last name like Smith, Drake, or Zenigata </small>-->
                       <label for="form-contact-company" class="">Your Title</label>
                     </div>
                   </div>
@@ -120,7 +197,9 @@
                   <!-- Grid column -->
                   <div class="col-md-12">
                     <div class="md-form mb-0">
-                      <textarea id="customerMessage" name="customerMessage" class="form-control md-textarea" rows="3" autocomplete="off"></textarea>
+                      <textarea id="customerMessageInput" name="customerMessageInput" class="form-control md-textarea" rows="3" autocomplete="off" onkeyup="checkMessage()"></textarea>
+                      <small class='error' id='customerMessageError'></small>
+                      <p></p>
                       <label for="form-contact-message">Your message about the artwork inquiry</label>
                     </div>
                   </div>
@@ -197,7 +276,7 @@
       </section>
       <!-- Section: Contact v.3 -->
     </div>
-    <!--Modal pop-up-->
+    <!--Modal pop-up
     <div class="modal fade" id="contactConfirmModal" tabindex="-1" role="dialog" aria-labelledby="contactConfirmModalLabel" aria-hidden="true">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -212,7 +291,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </div>-->
     </form> 
   </main>
   <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"


### PR DESCRIPTION
Added regex to the contact us page and modified the regex on the admin page to include either .png, .jpg, or .jpeg. Additionally, by using onkeyup rather than onkeydown, the regex now works without needing to space when you finish typing. Since the regex now works while typing, the temporary workaround of the length of 2 was changed to 3 in the admin year check.

Also got rid of the gallery image function that was still in the admin page since it wasn't necessary to have there.